### PR TITLE
Update Makefile for Mac Compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ DYN = lib$(TARGET)-$(VER).so
 #Compiling options
 CC = cc
 CFLAGS = -O3 -Wall -fno-strict-aliasing -fPIC
+#System check as -shared option for linker fails on MacOS
+ifneq ($(shell uname -s), Darwin)
+    OS_FLAG = -shared
+else
+    OS_FLAG =
+endif
 RM = rm -f
 
 #Recipes
@@ -30,7 +36,7 @@ all: $(DYN)
 
 #Build the shared library object
 $(DYN): $(OBJS)
-	$(CC) -o $@ -shared	$(CFLAGS) -Wl,-shared $(OBJS) -lc -lm -L$(PARI_LIB) -lpari
+		$(CC) -o $@ -shared	$(CFLAGS) -Wl,$(OS_FLAG) $(OBJS) -lc -lm -L$(PARI_LIB) -lpari
 
 #Make the object files
 %.o: %.c


### PR DESCRIPTION
Added a conditional based on OS. MacOS is not an ELF platform like Linux or WSL. This means that the -shared option of the linker causes make command to fail.

Unsure if -shared option is even necessary or not on other systems, unable to test on linux or windows but this should be functional